### PR TITLE
Make parallel

### DIFF
--- a/config/namelist.ini
+++ b/config/namelist.ini
@@ -52,6 +52,12 @@ imax = 1441
 jmin = 0
 jmax = 1020
 
+[parallel]
+submit_parallel = False
+nxcores = 2
+nycores = 2
+
+
 [options]
 use_daily_data  = False
 extract_full_depth = False

--- a/config/namelist_fulldepth.ini
+++ b/config/namelist_fulldepth.ini
@@ -52,6 +52,12 @@ imax = 1441
 jmin = 0
 jmax = 1020
 
+[parallel]
+submit_parallel = False
+nxcores = 2
+nycores = 2
+
+
 [options]
 use_daily_data  = False
 extract_full_depth = True

--- a/synthpro/model.py
+++ b/synthpro/model.py
@@ -57,11 +57,11 @@ class ModelData(object):
         if len(dat.shape) == 1:
             dat = dat[:]
         elif len(dat.shape) == 2:
-            dat = dat[self.jmin:self.jmax, self.imin:self.imax]
+            dat = dat[self.jmin:self.jmax+1, self.imin:self.imax+1]
         elif len(dat.shape) == 3:
-            dat = dat[:, self.jmin:self.jmax, self.imin:self.imax]
+            dat = dat[:, self.jmin:self.jmax+1, self.imin:self.imax+1]
         elif (len(dat.shape) == 4) & (dat.shape[0] == 1):
-            dat = dat[0, :, self.jmin:self.jmax, self.imin:self.imax]
+            dat = dat[0, :, self.jmin:self.jmax+1, self.imin:self.imax+1]
         else:
             raise ShapeError('%s has invalid shape: &s', ncvar,
                              repr(dat.shape))

--- a/synthpro/para.py
+++ b/synthpro/para.py
@@ -1,0 +1,94 @@
+"""
+Housekeeping routines for running synthpro in parallel using openMPI.
+
+"""
+
+import numpy as np
+
+import tools
+import profiles
+import printmsg
+
+def combine_profiles(args, config, size):
+    """
+    Combine synthetic profiles returned by each process and 
+    choose between any  duplicates using the minimum distance between 
+    ob and model location.
+    
+    """
+    synthDatFinal = profiles.assoc_profiles(config, 'synth_profiles')
+    
+    for nf in np.arange(size)[1:]:
+        printmsg.combining(nf+1, size)
+        oldsuffix = '_core%i.nc' % (nf - 1)
+        newsuffix = '_core%i.nc' % (nf)
+        
+        config = update_fpattern(config, 'synth_profiles',
+                  oldsuffix=oldsuffix, newsuffix=newsuffix)
+        config = tools.build_file_name(args, config, 'synth_profiles')
+        synthDat = profiles.assoc_profiles(config, 'synth_profiles')
+        
+        ind = np.where(synthDat.dists < synthDatFinal.dists)
+        if tools.idx_is_valid(ind):
+            synthDatFinal.dists[ind] = synthDat.dists[ind]
+            synthDatFinal.temps[ind] = synthDat.temps[ind]
+            synthDatFinal.sals[ind] = synthDat.sals[ind]
+            synthDatFinal.depths[ind] = synthDat.depths[ind]
+        
+        tools.rmfile(config.get('synth_profiles', 'file_name'))
+            
+    
+        
+    synthDatFinal.write_sals(synthDatFinal.sals)
+    synthDatFinal.write_temps(synthDatFinal.temps)
+    synthDatFinal.write_depths(synthDatFinal.depths)
+    synthDatFinal.write_dist(synthDatFinal.dists)
+
+
+def update_fpattern(config, section, oldsuffix='.nc', newsuffix='_suffix.nc'):
+    """
+    Update file path used to create synthetic profiles
+    to include rank of process.
+    
+    """
+    fpattern = config.get(section, 'fpattern')
+    fpattern = fpattern.replace(oldsuffix, newsuffix)
+    config.set(section, 'fpattern', value=fpattern)
+    
+    return config
+    
+
+def check_ncores(config, size):
+    """
+    Check that number of cores in MPI matches
+    nx/ny in namelist configuration file.
+    
+    """
+    nxcores = config.getint('parallel', 'nxcores')
+    nycores = config.getint('parallel', 'nycores')
+    
+    if size != nxcores*nycores:
+        raise ValueError('Number of MPI cores != nxcores * nycores')
+    
+
+def update_ij_range(config, rank):
+    """ Update model imin/imax and jmin/jmax for the specified core"""
+
+    nxcores= config.getint('parallel', 'nxcores')
+    nycores= config.getint('parallel', 'nycores')
+
+    for data_type in ['model_temp', 'model_sal']:
+        imin = config.getint(data_type, 'imin')
+        imax = config.getint(data_type, 'imax')
+        jmin = config.getint(data_type, 'jmin')
+        jmax = config.getint(data_type, 'jmax')
+        
+        ni = imax - imin + 1
+        nj = jmax - jmin + 1
+        imins, imaxs, jmins, jmaxs = tools.mapcores(ni, nj, nxcores, nycores)
+        config.set(data_type, 'imin', value='%i' % imins[rank])
+        config.set(data_type, 'imax', value='%i' % imaxs[rank])
+        config.set(data_type, 'jmin', value='%i' % jmins[rank])
+        config.set(data_type, 'jmax', value='%i' % jmaxs[rank])
+        
+    return

--- a/synthpro/printmsg.py
+++ b/synthpro/printmsg.py
@@ -14,6 +14,9 @@ def extracting(n, nmax):
     """ Print progress bar for extraction of data"""
     tools.print_progress('Extracting synthetic data', nmax, n)
     
+def combining(n, nmax):
+    """ Print progress bar for combining synthetic profiles"""
+    tools.print_progress('Combining synthetic data', nmax, n)
     
 def writing(n, nmax):
     """ Print progress bar for extraction of data"""

--- a/synthpro/profiles.py
+++ b/synthpro/profiles.py
@@ -41,7 +41,15 @@ class Profiles(object):
             
         if profile_type == 'synth_profiles':
             self.dist_var = 'distance_to_ob'
-            self.duplicate_var(self.lat_var, self.dist_var)
+            ncf = Dataset(self.f, 'r')
+            vars = ncf.variables.keys()
+            ncf.close()
+            
+            if self.dist_var in vars :
+                self.load_dists()
+            else:
+                self.duplicate_var(self.lat_var, self.dist_var)
+            
             
     def duplicate_var(self, ncvar1, ncvar2):
         """ Create new variable based on existing variable """
@@ -82,28 +90,33 @@ class Profiles(object):
         """ Write depth data to file. """
         self.write_var(self.sal_var, dat)
                 
+    def load_dists(self):
+        """ Load distances as <np.array> with dimensions [n] """
+        self.dists = self.read_var(self.dist_var)
+        self.test_shape(self.dist_var, self.dists.shape, 1)
+    
     def load_temps(self):
-        """ Load temperatures as <np.array> with dimensions [t, z] """
+        """ Load temperatures as <np.array> with dimensions [n, z] """
         self.temps = self.read_var(self.temp_var)
         self.test_shape(self.temp_var, self.temps.shape, 2)
         
     def load_sals(self):
-        """ Load salinities as <np.array> with dimensions [t, z] """
+        """ Load salinities as <np.array> with dimensions [n, z] """
         self.sals = self.read_var(self.sal_var)
         self.test_shape(self.sal_var, self.sals.shape, 2)
         
     def load_depths(self):
-        """ Load depths as <np.array> with dimensions [t, z] """
+        """ Load depths as <np.array> with dimensions [n, z] """
         self.depths = self.read_var(self.depth_var)
         self.test_shape(self.depth_var, self.depths.shape, 2)
         
     def load_lats(self):
-        """ Load latitudes as <np.array> with dimensions [t] """
+        """ Load latitudes as <np.array> with dimensions [n] """
         self.lats = self.read_var(self.lat_var)
         self.test_shape(self.lat_var, self.lats.shape, 1)
         
     def load_lons(self):
-        """ Load longitudes as <np.array> with dimensions [t] """
+        """ Load longitudes as <np.array> with dimensions [n] """
         self.lons = self.read_var(self.lon_var)
         self.test_shape(self.lon_var, self.lons.shape, 1)
         

--- a/synthpro/synthpro.py
+++ b/synthpro/synthpro.py
@@ -5,28 +5,28 @@ Module containing main routines to execute synthpro.
 
 import parse_args
 import namelist
+from mpi4py import MPI
+import numpy as np
 
 import profiles
 import model
 import extract
 import tools
 import printmsg
+import para
 
 
-def main():
-    """ Execute synthetic profile extraction code """
-        
-    # Parse arguments and configuration files
-    args = parse_args.get_args()
-    config = namelist.get_namelist(args)
+def main_singlenode(args, config):
+    """ Run a single instance of synthpro """
+    
     if config.getboolean('options', 'print_stdout'): 
         printmsg.start(args, config)
     
     # Build paths to data files
-    tools.build_file_name(args, config, 'obs_profiles')
-    tools.build_file_name(args, config, 'synth_profiles')
-    tools.build_file_name(args, config, 'model_temp')
-    tools.build_file_name(args, config, 'model_sal') 
+    config = tools.build_file_name(args, config, 'obs_profiles')
+    config = tools.build_file_name(args, config, 'synth_profiles')
+    config = tools.build_file_name(args, config, 'model_temp')
+    config = tools.build_file_name(args, config, 'model_sal') 
     if config.getboolean('options', 'print_stdout'): 
         printmsg.inputs(config)
     
@@ -45,8 +45,48 @@ def main():
     
     # Extract profiles
     extract.extract_profiles(config, obsDat, synthDat, modelTemp, modelSal)
+
+
+def main_parallel(args, config):
+    """ Run synthpro in parallel using openMPI """
     
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+    
+    if rank == 0:
+        para.check_ncores(config, size)
+    else:
+        config.set('options', 'print_stdout', value='False')
+    
+    para.update_ij_range(config, rank)
+    config = para.update_fpattern(config, 'synth_profiles',
+                  newsuffix=('_core%i.nc' % rank))
+
+    main_singlenode(args, config)
+    comm.Barrier()
+    
+    if rank == 0:
+        para.combine_profiles(args, config, size)
+
+
+def main():
+    """
+    Parse command line arguments and options and run synthpro.
+    
+    """
+
+    args = parse_args.get_args()
+    config = namelist.get_namelist(args)
+    
+    if config.getboolean('parallel', 'submit_parallel'):
+        main_parallel(args, config)
+    else:
+        main_singlenode(args, config)
+        
     # Finished
     if config.getboolean('options', 'print_stdout'): 
         printmsg.finished()
  
+    
+

--- a/synthpro/tests/test_tools.py
+++ b/synthpro/tests/test_tools.py
@@ -4,9 +4,28 @@ Unit tests for functions in tools module.
 """
 import unittest
 import numpy as np
+import matplotlib.pyplot as plt
 
 import tools
 
+class TestMapCores(unittest.TestCase):
+    """ Unit tests for <tools.mapcores> """
+
+    def test_mapcores_complete(self):
+        """ Ensures that all regions of model data are correctly indexed
+        following mapping to different cores """
+        nj, ni = 1000, 2000
+        nycores, nxcores = 7, 3
+        ncores = nxcores * nycores
+        dat = np.zeros(nj * ni).reshape(nj, ni)
+        imins, imaxs, jmins, jmaxs = tools.mapcores(ni, nj, nxcores, nycores)
+
+        for ncore in range(ncores):
+            imin, imax = imins[ncore], imaxs[ncore] + 1
+            jmin, jmax = jmins[ncore], jmaxs[ncore] + 1
+            dat[jmin:jmax, imin:imax] += 1
+
+        self.assertTrue((dat == 1).all())
 
 class TestIdxIsValid(unittest.TestCase):
     """ Unit tests for <tools.idx_is_valid> """
@@ -168,10 +187,13 @@ class TestFindNearest(unittest.TestCase):
         """
         lats = np.arange(90).reshape(9,10)/10
         lons = (np.arange(90)).reshape(10,9).T/9
-        self.assertEqual(tools.find_nearest_neigbour(0, 0, lats, lons), (0, 0))
-        self.assertEqual(tools.find_nearest_neigbour(10, 10, lats, lons), (8, 9))
         
-    
-
+        iind, jind, d = tools.find_nearest_neigbour(0, 0, lats, lons)
+        self.assertEqual((iind, jind), (0, 0))
+        iind, jind, d = tools.find_nearest_neigbour(8, 9, lats, lons)
+        self.assertEqual((iind, jind), (8, 9))
+        iind, jind, d = tools.find_nearest_neigbour(20, 20, lats, lons)
+        self.assertEqual((iind, jind), (None, None))
+        
 if __name__ == '__main__':
     unittest.main()

--- a/synthpro/tools.py
+++ b/synthpro/tools.py
@@ -4,7 +4,41 @@ Useful functions
 """
 
 import numpy as np
+import os
 
+def rmfile(f):
+    """
+    Delete specified file.
+    
+    """
+    os.remove(f)
+    
+    
+def mapcores(ni, nj, nxcores, nycores):
+    """ 
+    Return maps of imin, imax, jmin, jmax for each core.
+    
+    """
+    ncores = nxcores * nycores
+    coreshape = (nycores, nxcores)
+    imin = np.zeros(coreshape)
+    imax = np.zeros(coreshape)
+    jmin = np.zeros(coreshape)
+    jmax = np.zeros(coreshape)
+    
+    jinds = np.array_split(np.arange(nj), nycores)
+    iinds = np.array_split(np.arange(ni), nxcores)
+
+    for nx in range(nxcores):
+        for ny in range(nycores):
+            imin[ny, nx] = iinds[nx].min()
+            imax[ny, nx] = iinds[nx].max()
+            jmin[ny, nx] = jinds[ny].min()
+            jmax[ny, nx] = jinds[ny].max()
+    
+    return (imin.reshape(ncores), imax.reshape(ncores), 
+            jmin.reshape(ncores), jmax.reshape(ncores))
+    
 
 def idx_is_valid(ind):
     """ Return False if index returned by <np.where> is empty. """
@@ -192,4 +226,8 @@ def build_file_name(args, config, section):
     f = config.get(section, 'dir') + config.get(section, 'fpattern')
     f = insert_date(args, config, f)
     config.set(section, 'file_name', value=f)
+    
+    return config
+    
+
     


### PR DESCRIPTION
This branch adds compatibility with openMPI through use of the mpi4py library and allows synthpro to be applied to very-high resolution data sets by limiting the memory consumption of any individual process. 

Model data is decomposed into a number of "chunks" (determined by nxcore/nycore in namelist.ini) that are processed on separate cores/compute nodes. Each process tests all profiles to determine if the observed location falls within the limited model domain. When all processes are completed, the extracted profiles are combined into a single netcdf file that is equivalent to the file produced by running synthpro as a single process. 

This closes closes #6.